### PR TITLE
Add `serde` feature for type (de)serialization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0]
+### Added
+- Serde `derive(Serialize,Deserialize)` for all types when using the `serde` feature.
+
 ## [0.1.1]
 ### Added
 - `PartialEq<{float}>` for all types. Meaning one can write:
@@ -21,5 +25,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial version
 
-[Unreleased]: https://github.com/RazrFalcon/strict-num/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/RazrFalcon/strict-num/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/RazrFalcon/strict-num/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/RazrFalcon/strict-num/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strict-num"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Yevhenii Reizner <razrfalcon@gmail.com>"]
 license = "MIT"
 description = "A collection of bounded numeric types"
@@ -11,7 +11,13 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-float-cmp = { version = "0.9", default-features = false, features = ["std"], optional = true }
+float-cmp = { version = "0.9", optional = true, default-features = false, features = [
+    "std",
+] }
+serde = { version = "1.0.163", optional = true, default-features = false, features = [
+    "derive",
+] }
+
 
 [features]
 default = ["approx-eq"]
@@ -20,3 +26,4 @@ default = ["approx-eq"]
 # via the `float-cmp` crate.
 # Disables `no_std`.
 approx-eq = ["float-cmp"]
+serde = ["dep:serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,9 +93,13 @@ macro_rules! impl_approx_64 {
     ($t:ident) => {};
 }
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// An immutable, finite `f32`.
 ///
 /// Unlike `f32`, implements `Ord`, `PartialOrd` and `Hash`.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Default, Debug)]
 #[repr(transparent)]
 pub struct FiniteF32(f32);
@@ -179,6 +183,7 @@ impl_approx_32!(FiniteF32);
 /// An immutable, finite `f64`.
 ///
 /// Unlike `f64`, implements `Ord`, `PartialOrd` and `Hash`.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Default, Debug)]
 #[repr(transparent)]
 pub struct FiniteF64(f64);
@@ -260,6 +265,7 @@ impl_display!(FiniteF64);
 impl_approx_64!(FiniteF64);
 
 /// An immutable, finite `f32` that is known to be >= 0.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Debug)]
 #[repr(transparent)]
 pub struct PositiveF32(FiniteF32);
@@ -314,6 +320,7 @@ impl_display!(PositiveF32);
 impl_approx_32!(PositiveF32);
 
 /// An immutable, finite `f64` that is known to be >= 0.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Debug)]
 #[repr(transparent)]
 pub struct PositiveF64(FiniteF64);
@@ -368,6 +375,7 @@ impl_display!(PositiveF64);
 impl_approx_64!(PositiveF64);
 
 /// An immutable, finite `f32` that is known to be > 0.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[repr(transparent)]
 pub struct NonZeroPositiveF32(FiniteF32);
@@ -419,6 +427,7 @@ impl_display!(NonZeroPositiveF32);
 impl_approx_32!(NonZeroPositiveF32);
 
 /// An immutable, finite `f64` that is known to be > 0.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[repr(transparent)]
 pub struct NonZeroPositiveF64(FiniteF64);
@@ -470,6 +479,7 @@ impl_display!(NonZeroPositiveF64);
 impl_approx_64!(NonZeroPositiveF64);
 
 /// An immutable, finite `f32` in a 0..=1 range.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[repr(transparent)]
 pub struct NormalizedF32(FiniteF32);
@@ -569,6 +579,7 @@ impl_display!(NormalizedF32);
 impl_approx_32!(NormalizedF32);
 
 /// An immutable, finite `f64` in a 0..=1 range.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[repr(transparent)]
 pub struct NormalizedF64(FiniteF64);


### PR DESCRIPTION
Hey @RazrFalcon, I'm experimenting with using resvg in a [Tauri](https://next--tauri.netlify.app/) application and a requirement for sending/receiving things between frontend/backend is serde. If I end up using resvg I will need to send `usvg::Tree` data types across that boundary. In an effort to make that possible, I wanted to get a `serde` feature for types in `strict-num`, then do the same for `tiny-skia`, then `usvg`, and finally `resvg`. This is my attempt at that first step. 

Is this a feature you would find helpful and/or acceptable for `resvg` and its dependencies?

If there's anything you don't like about this PR, or anything you want me to change, please let me know! I've not actually written a Rust library feature before so any feedback would be appreciated. 😬 