### PR TITLE
Fixes `Display` and Adds Other Formatting Traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Fixed the implementation of `Display` for all types: now the formatting arguments are properly used and the result is identical to the one produced by [`f32`] or [`f64`].
 
 ## [0.2.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 - Fixed the implementation of `Display` for all types: now the formatting arguments are properly used and the result is identical to the one produced by [`f32`] or [`f64`].
+- Implemented `LowerExp` and `UpperExp` for all types.
 
 ## [0.2.0]
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.56"
 
 [dependencies]
 float-cmp = { version = "0.9", default-features = false, features = ["std"], optional = true }
+derive_more = { version = "0.99", default-features = false, features = ["display"] }
 serde = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ mod serde;
 #[cfg(feature = "approx-eq")]
 pub use float_cmp::{ApproxEq, ApproxEqUlps, Ulps};
 
-use derive_more::Display;
+use derive_more::{Display, LowerExp, UpperExp};
 
 #[cfg(feature = "approx-eq")]
 macro_rules! impl_approx_32 {
@@ -95,7 +95,7 @@ macro_rules! impl_approx_64 {
 /// An immutable, finite [`f32`].
 ///
 /// Unlike [`f32`], implements [`Eq`], [`Ord`] and [`Hash`].
-#[derive(Copy, Clone, Default, Debug, Display)]
+#[derive(Copy, Clone, Default, Debug, Display, LowerExp, UpperExp)]
 #[repr(transparent)]
 pub struct FiniteF32(f32);
 
@@ -177,7 +177,7 @@ impl_approx_32!(FiniteF32);
 /// An immutable, finite [`f64`].
 ///
 /// Unlike [`f64`], implements [`Eq`], [`Ord`] and [`Hash`].
-#[derive(Copy, Clone, Default, Debug, Display)]
+#[derive(Copy, Clone, Default, Debug, Display, LowerExp, UpperExp)]
 #[repr(transparent)]
 pub struct FiniteF64(f64);
 
@@ -257,7 +257,9 @@ impl PartialEq<f64> for FiniteF64 {
 impl_approx_64!(FiniteF64);
 
 /// An immutable, finite [`f32`] that is known to be >= 0.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Debug, Display)]
+#[derive(
+    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Debug, Display, LowerExp, UpperExp,
+)]
 #[repr(transparent)]
 pub struct PositiveF32(FiniteF32);
 
@@ -310,7 +312,9 @@ impl PartialEq<f32> for PositiveF32 {
 impl_approx_32!(PositiveF32);
 
 /// An immutable, finite [`f64`] that is known to be >= 0.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Debug, Display)]
+#[derive(
+    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Debug, Display, LowerExp, UpperExp,
+)]
 #[repr(transparent)]
 pub struct PositiveF64(FiniteF64);
 
@@ -363,7 +367,7 @@ impl PartialEq<f64> for PositiveF64 {
 impl_approx_64!(PositiveF64);
 
 /// An immutable, finite [`f32`] that is known to be > 0.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Display)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Display, LowerExp, UpperExp)]
 #[repr(transparent)]
 pub struct NonZeroPositiveF32(FiniteF32);
 
@@ -413,7 +417,7 @@ impl PartialEq<f32> for NonZeroPositiveF32 {
 impl_approx_32!(NonZeroPositiveF32);
 
 /// An immutable, finite [`f64`] that is known to be > 0.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Display)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Display, LowerExp, UpperExp)]
 #[repr(transparent)]
 pub struct NonZeroPositiveF64(FiniteF64);
 
@@ -463,7 +467,7 @@ impl PartialEq<f64> for NonZeroPositiveF64 {
 impl_approx_64!(NonZeroPositiveF64);
 
 /// An immutable, finite [`f32`] in a 0..=1 range.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Display)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Display, LowerExp, UpperExp)]
 #[repr(transparent)]
 pub struct NormalizedF32(FiniteF32);
 
@@ -561,7 +565,7 @@ impl PartialEq<f32> for NormalizedF32 {
 impl_approx_32!(NormalizedF32);
 
 /// An immutable, finite [`f64`] in a 0..=1 range.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Display)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Display, LowerExp, UpperExp)]
 #[repr(transparent)]
 pub struct NormalizedF64(FiniteF64);
 
@@ -696,6 +700,36 @@ mod tests {
         );
     }
 
+    /// Test that the [`LowerExp`] implementation of [`FiniteF32`] is equivalent to the
+    /// one of [`f32`] for a single example.
+    #[test]
+    fn test_finite_f32_lower_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:e}",
+                FiniteF32::new(core::f32::consts::PI).unwrap()
+            )),
+            second_buffer.format(format_args!("{:e}", core::f32::consts::PI)),
+        );
+    }
+
+    /// Test that the [`UpperExp`] implementation of [`FiniteF32`] is equivalent to the
+    /// one of [`f32`] for a single example.
+    #[test]
+    fn test_finite_f32_upper_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:E}",
+                FiniteF32::new(core::f32::consts::PI).unwrap()
+            )),
+            second_buffer.format(format_args!("{:E}", core::f32::consts::PI)),
+        );
+    }
+
     /// Test that the [`Display`] implementation of [`FiniteF64`] is equivalent to the
     /// one of [`f64`].
     #[test]
@@ -708,6 +742,36 @@ mod tests {
                 FiniteF64::new(core::f64::consts::PI).unwrap()
             )),
             second_buffer.format(format_args!("{:.5}", core::f64::consts::PI)),
+        );
+    }
+
+    /// Test that the [`LowerExp`] implementation of [`FiniteF64`] is equivalent to the
+    /// one of [`f64`] for a single example.
+    #[test]
+    fn test_finite_f64_lower_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:e}",
+                FiniteF64::new(core::f64::consts::PI).unwrap()
+            )),
+            second_buffer.format(format_args!("{:e}", core::f64::consts::PI)),
+        );
+    }
+
+    /// Test that the [`UpperExp`] implementation of [`FiniteF64`] is equivalent to the
+    /// one of [`f64`] for a single example.
+    #[test]
+    fn test_finite_f64_upper_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:E}",
+                FiniteF64::new(core::f64::consts::PI).unwrap()
+            )),
+            second_buffer.format(format_args!("{:E}", core::f64::consts::PI)),
         );
     }
 
@@ -744,6 +808,36 @@ mod tests {
         );
     }
 
+    /// Test that the [`LowerExp`] implementation of [`PositiveF32`] is equivalent to
+    /// the one of [`f32`] for a single example.
+    #[test]
+    fn test_positive_f32_lower_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:e}",
+                PositiveF32::new(core::f32::consts::PI).unwrap()
+            )),
+            second_buffer.format(format_args!("{:e}", core::f32::consts::PI)),
+        );
+    }
+
+    /// Test that the [`UpperExp`] implementation of [`PositiveF32`] is equivalent to
+    /// the one of [`f32`] for a single example.
+    #[test]
+    fn test_positive_f32_upper_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:E}",
+                PositiveF32::new(core::f32::consts::PI).unwrap()
+            )),
+            second_buffer.format(format_args!("{:E}", core::f32::consts::PI)),
+        );
+    }
+
     #[test]
     fn positive_f64() {
         assert_eq!(NonZeroPositiveF32::new(-1.0).map(|n| n.get()), None);
@@ -777,6 +871,36 @@ mod tests {
         );
     }
 
+    /// Test that the [`LowerExp`] implementation of [`PositiveF64`] is equivalent to
+    /// the one of [`f64`] for a single example.
+    #[test]
+    fn test_positive_f64_lower_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:e}",
+                PositiveF64::new(core::f64::consts::PI).unwrap()
+            )),
+            second_buffer.format(format_args!("{:e}", core::f64::consts::PI)),
+        );
+    }
+
+    /// Test that the [`UpperExp`] implementation of [`PositiveF64`] is equivalent to
+    /// the one of [`f64`] for a single example.
+    #[test]
+    fn test_positive_f64_upper_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:E}",
+                PositiveF64::new(core::f64::consts::PI).unwrap()
+            )),
+            second_buffer.format(format_args!("{:E}", core::f64::consts::PI)),
+        );
+    }
+
     /// Test that the [`Display`] implementation of [`NonZeroPositiveF32`] is equivalent
     /// to the one of [`f32`].
     #[test]
@@ -792,6 +916,36 @@ mod tests {
         );
     }
 
+    /// Test that the [`LowerExp`] implementation of [`NonZeroPositiveF32`] is
+    /// equivalent to the one of [`f32`] for a single example.
+    #[test]
+    fn test_nonzero_positive_f32_lower_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:e}",
+                NonZeroPositiveF32::new(core::f32::consts::PI).unwrap()
+            )),
+            second_buffer.format(format_args!("{:e}", core::f32::consts::PI)),
+        );
+    }
+
+    /// Test that the [`UpperExp`] implementation of [`NonZeroPositiveF32`] is
+    /// equivalent to the one of [`f32`] for a single example.
+    #[test]
+    fn test_nonzero_positive_f32_upper_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:E}",
+                NonZeroPositiveF32::new(core::f32::consts::PI).unwrap()
+            )),
+            second_buffer.format(format_args!("{:E}", core::f32::consts::PI)),
+        );
+    }
+
     /// Test that the [`Display`] implementation of [`NonZeroPositiveF64`] is equivalent
     /// to the one of [`f64`].
     #[test]
@@ -804,6 +958,36 @@ mod tests {
                 NonZeroPositiveF64::new(core::f64::consts::PI).unwrap()
             )),
             second_buffer.format(format_args!("{:.5}", core::f64::consts::PI)),
+        );
+    }
+
+    /// Test that the [`LowerExp`] implementation of [`NonZeroPositiveF64`] is
+    /// equivalent to the one of [`f64`] for a single example.
+    #[test]
+    fn test_nonzero_positive_f64_lower_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:e}",
+                NonZeroPositiveF64::new(core::f64::consts::PI).unwrap()
+            )),
+            second_buffer.format(format_args!("{:e}", core::f64::consts::PI)),
+        );
+    }
+
+    /// Test that the [`UpperExp`] implementation of [`NonZeroPositiveF64`] is
+    /// equivalent to the one of [`f64`] for a single example.
+    #[test]
+    fn test_nonzero_positive_f64_upper_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:E}",
+                NonZeroPositiveF64::new(core::f64::consts::PI).unwrap()
+            )),
+            second_buffer.format(format_args!("{:E}", core::f64::consts::PI)),
         );
     }
 
@@ -851,6 +1035,36 @@ mod tests {
         );
     }
 
+    /// Test that the [`LowerExp`] implementation of [`NormalizedF32`] is equivalent to
+    /// the one of [`f32`] for a single example.
+    #[test]
+    fn test_normalized_f32_lower_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:e}",
+                NormalizedF32::new(core::f32::consts::FRAC_1_SQRT_2).unwrap()
+            )),
+            second_buffer.format(format_args!("{:e}", core::f32::consts::FRAC_1_SQRT_2)),
+        );
+    }
+
+    /// Test that the [`UpperExp`] implementation of [`NormalizedF32`] is equivalent to
+    /// the one of [`f32`] for a single example.
+    #[test]
+    fn test_normalized_f32_upper_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:E}",
+                NormalizedF32::new(core::f32::consts::FRAC_1_SQRT_2).unwrap()
+            )),
+            second_buffer.format(format_args!("{:E}", core::f32::consts::FRAC_1_SQRT_2)),
+        );
+    }
+
     #[test]
     fn norm_f64() {
         assert_eq!(NormalizedF64::new(-0.5), None);
@@ -892,6 +1106,36 @@ mod tests {
                 NormalizedF64::new(core::f64::consts::FRAC_1_SQRT_2).unwrap()
             )),
             second_buffer.format(format_args!("{:.5}", core::f64::consts::FRAC_1_SQRT_2)),
+        );
+    }
+
+    /// Test that the [`LowerExp`] implementation of [`NormalizedF64`] is equivalent to
+    /// the one of [`f64`] for a single example.
+    #[test]
+    fn test_normalized_f64_lower_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:e}",
+                NormalizedF64::new(core::f64::consts::FRAC_1_SQRT_2).unwrap()
+            )),
+            second_buffer.format(format_args!("{:e}", core::f64::consts::FRAC_1_SQRT_2)),
+        );
+    }
+
+    /// Test that the [`UpperExp`] implementation of [`NormalizedF64`] is equivalent to
+    /// the one of [`f64`] for a single example.
+    #[test]
+    fn test_normalized_f64_upper_exp() {
+        let mut first_buffer = WriteTo::<10>::default();
+        let mut second_buffer = WriteTo::<10>::default();
+        assert_eq!(
+            first_buffer.format(format_args!(
+                "{:E}",
+                NormalizedF64::new(core::f64::consts::FRAC_1_SQRT_2).unwrap()
+            )),
+            second_buffer.format(format_args!("{:E}", core::f64::consts::FRAC_1_SQRT_2)),
         );
     }
 


### PR DESCRIPTION
# TL;DR
Hi, thanks for accepting my previous pull request. This one fixes what I feel like is an issue with the current implementation of `Display` and adds support for the `LowerExp` and `UpperExp` formatting traits. With this PR the newtypes of `strict-num` would implement all and only the formatting traits that are avaiable on the floating point primitive types. Morover, with the exception of `Debug`, their implementation would be equivalent to the one of `f32` and `f64`.

As before, I'm open to any feedback or change proposal.

## Details
The current version of `strict-num` ignores the formatting arguments that are passed to `Display`, but I would expect to be able to format `strict-num`'s newtypes as if they were their corresponding primitive type.

Accodingly, the first of the two commits swaps the current macro-based implementation for the one from `derive_more`, which simply forwards to the `Display::fmt` method of the corresponding primitive type.

The main drawback of these changes is that they require adding a new dependency, which increases compile times. On the flip side, `derive_more` makes it easy to implement a few other traits, such as:
- `LowerExp` and `UpperExp`, that are added in the second commit.
- Conversion traits as `From<PositiveF32>` for `FiniteF32` and `f32`, which could be added in a future pull request.

Moreover, `derive_more` is fully compatible with a `#![no_std]` environment, so it doesn't break `strict-num`'s support for embedded development. Finally, `derive_more` is a completely private dependency[^1], so it wouldn't cause any compatibility problems for downstream crates.

[^1]: By this I mean that nothing from `derive_more` would be exposed to downstream crates, so there's no risk of conflict with other dependencies that require incompatibile versions of `derive_more`.

## A Note About Testing
Testing these traits in a `#![no_std]` environment has been tricky because it's impossibile to use the `format!` macro. I used a solution (adapted from StackOverflow) that relies on fixed-size, stack allocated strings. It would be better to rely on the [`heapless`](https://docs.rs/heapless/0.8.0/heapless/) crate, but one of its dependencies requires Rust 1.60+. I don't think that it's worth increasing the MSRV for such a minimal usage of a test utility, but if this PR is accepted we might want to open an issue to keep track of this problem, so that when the MSRV will be increased again it will be easy to remember of [`heapless`].


Edit: added note about `#![no_std]`.

[`String`]: https://docs.rs/heapless/0.8.0/heapless/struct.String.html
[`heapless`]: https://docs.rs/heapless/0.8.0/heapless/
